### PR TITLE
Add ChangelogAutomation.Changelog project and improve note handling

### DIFF
--- a/ChangelogAutomation.Changelog/ChangelogAutomation.Changelog.csproj
+++ b/ChangelogAutomation.Changelog/ChangelogAutomation.Changelog.csproj
@@ -1,0 +1,46 @@
+﻿<Project Sdk="Microsoft.Build.NoTargets/3.7.56">
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+    
+    <UsingTask TaskName="BuildChangelogTxt"
+               TaskFactory="RoslynCodeTaskFactory"
+               AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+        <ParameterGroup>
+            <ChangelogFile Required="true" ParameterType="System.String" />
+            <PlainTextFile Output="true" ParameterType="System.String" />
+        </ParameterGroup>
+        <Task>
+            <Using Namespace="System.Diagnostics"/>
+            <Code Type="Fragment" Language="cs">
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "dotnet",
+                    Arguments = $"run --project ../ChangelogAutomation/ChangelogAutomation.csproj -- \"{ChangelogFile}\" --content-type PlainText",
+                    RedirectStandardOutput = true
+                };
+                using var process = Process.Start(psi);
+                var content = process.StandardOutput.ReadToEnd();
+                process.WaitForExit();
+                if (process.ExitCode != 0)
+                {
+                    Log.LogError($"Process returned exit code {process.ExitCode}");
+                    return false;
+                }
+
+                File.WriteAllText(PlainTextFile, content);
+            </Code>
+        </Task>
+    </UsingTask>
+
+    <Target Name="PrepareChangelog"
+            BeforeTargets="Pack"
+            Inputs="..\CHANGELOG.md"
+            Outputs="bin\changelog.txt">
+        <MakeDir Directories="bin" />
+        <Message Importance="high" Text="Extracting release notes from ../CHANGELOG.md" />
+        <BuildChangelogTxt ChangelogFile="..\CHANGELOG.md" PlainTextFile="bin\changelog.txt"/>
+    </Target>
+    
+</Project>

--- a/ChangelogAutomation.MSBuild/ChangelogAutomation.MSBuild.csproj
+++ b/ChangelogAutomation.MSBuild/ChangelogAutomation.MSBuild.csproj
@@ -28,9 +28,9 @@
     <Import Project="..\SetPackageReleaseNotesExternal.tasks" />
     <Target Name="SetPackageReleaseNotesExternal"
             AfterTargets="GetPackageMetadata" BeforeTargets="GenerateNuSpec">
-        <Message Importance="high" Text="Extracting release notes from ../CHANGELOG.md" />
-        <SetPackageReleaseNotesExternal ChangelogFile="..\CHANGELOG.md">
-            <Output TaskParameter="PlainText" PropertyName="PackageReleaseNotes" />
+        <Message Importance="high" Text="Preparing the release notes..." />
+        <SetPackageReleaseNotesExternal TextFile="..\ChangelogAutomation.Changelog\bin\changelog.txt">
+            <Output TaskParameter="Text" PropertyName="PackageReleaseNotes" />
         </SetPackageReleaseNotesExternal>
         <ItemGroup>
             <PackageMetadata Update="$(PackageId)">
@@ -62,6 +62,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\ChangelogAutomation.Changelog\ChangelogAutomation.Changelog.csproj" ReferenceOutputAssembly="false" />
         <ProjectReference Include="..\ChangelogAutomation.Core\ChangelogAutomation.Core.csproj" PrivateAssets="All" />
         <PackageReference Include="Markdig" Version="0.41.0" GeneratePathProperty="true" />
     </ItemGroup>

--- a/ChangelogAutomation.Tool/ChangelogAutomation.Tool.csproj
+++ b/ChangelogAutomation.Tool/ChangelogAutomation.Tool.csproj
@@ -21,9 +21,9 @@
     <Import Project="..\SetPackageReleaseNotesExternal.tasks" />
     <Target Name="SetPackageReleaseNotesExternal"
             AfterTargets="GetPackageMetadata" BeforeTargets="GenerateNuSpec">
-        <Message Importance="high" Text="Extracting release notes from ../CHANGELOG.md" />
-        <SetPackageReleaseNotesExternal ChangelogFile="..\CHANGELOG.md">
-            <Output TaskParameter="PlainText" PropertyName="PackageReleaseNotes" />
+        <Message Importance="high" Text="Preparing the release notes..." />
+        <SetPackageReleaseNotesExternal TextFile="..\ChangelogAutomation.Changelog\bin\changelog.txt">
+            <Output TaskParameter="Text" PropertyName="PackageReleaseNotes" />
         </SetPackageReleaseNotesExternal>
         <ItemGroup>
             <PackageMetadata Update="$(PackageId)">
@@ -39,6 +39,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\ChangelogAutomation.Changelog\ChangelogAutomation.Changelog.csproj"  ReferenceOutputAssembly="false" />
       <ProjectReference Include="..\ChangelogAutomation\ChangelogAutomation.csproj" />
     </ItemGroup>
 

--- a/ChangelogAutomation.sln
+++ b/ChangelogAutomation.sln
@@ -25,8 +25,6 @@ ProjectSection(SolutionItems) = preProject
 	.github\workflows\release.yml = .github\workflows\release.yml
 EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChangelogAutomation.Core", "ChangelogAutomation.Core\ChangelogAutomation.Core.csproj", "{7E6BB5C3-1362-4D99-BCA9-F48746500C8E}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChangelogAutomation.MSBuild", "ChangelogAutomation.MSBuild\ChangelogAutomation.MSBuild.csproj", "{E92C594F-1B03-4AFB-8419-626F3AFCAFA2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChangelogAutomation.MSBuild.Tests", "ChangelogAutomation.MSBuild.Tests\ChangelogAutomation.MSBuild.Tests.proj", "{D8504D94-4960-4288-8052-76054DF8FCBA}"
@@ -37,6 +35,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{C5DC
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChangelogAutomation.Tool", "ChangelogAutomation.Tool\ChangelogAutomation.Tool.csproj", "{734CE25E-E176-4C25-9392-8904576A3108}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChangelogAutomation.Core", "ChangelogAutomation.Core\ChangelogAutomation.Core.csproj", "{FA3C6D86-4A52-434B-B0D8-79AE508AE1FD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChangelogAutomation.Changelog", "ChangelogAutomation.Changelog\ChangelogAutomation.Changelog.csproj", "{E3A7ACDC-465D-4CFF-A76D-906F8101E00C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -52,10 +54,6 @@ Global
 		{F6BE3958-9982-4D7A-8418-ABCC0DEEF314}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F6BE3958-9982-4D7A-8418-ABCC0DEEF314}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F6BE3958-9982-4D7A-8418-ABCC0DEEF314}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7E6BB5C3-1362-4D99-BCA9-F48746500C8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7E6BB5C3-1362-4D99-BCA9-F48746500C8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7E6BB5C3-1362-4D99-BCA9-F48746500C8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7E6BB5C3-1362-4D99-BCA9-F48746500C8E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E92C594F-1B03-4AFB-8419-626F3AFCAFA2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E92C594F-1B03-4AFB-8419-626F3AFCAFA2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E92C594F-1B03-4AFB-8419-626F3AFCAFA2}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -64,6 +62,14 @@ Global
 		{734CE25E-E176-4C25-9392-8904576A3108}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{734CE25E-E176-4C25-9392-8904576A3108}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{734CE25E-E176-4C25-9392-8904576A3108}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA3C6D86-4A52-434B-B0D8-79AE508AE1FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA3C6D86-4A52-434B-B0D8-79AE508AE1FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA3C6D86-4A52-434B-B0D8-79AE508AE1FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA3C6D86-4A52-434B-B0D8-79AE508AE1FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E3A7ACDC-465D-4CFF-A76D-906F8101E00C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E3A7ACDC-465D-4CFF-A76D-906F8101E00C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E3A7ACDC-465D-4CFF-A76D-906F8101E00C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E3A7ACDC-465D-4CFF-A76D-906F8101E00C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{E756D5CD-583F-403A-BFB7-4650D0EDE896} = {D3406BE3-88EB-4F79-93DE-4C8686581FE9}

--- a/SetPackageReleaseNotesExternal.tasks
+++ b/SetPackageReleaseNotesExternal.tasks
@@ -3,26 +3,12 @@
                TaskFactory="RoslynCodeTaskFactory"
                AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
         <ParameterGroup>
-            <ChangelogFile Required="true" ParameterType="System.String" />
-            <PlainText Output="true" ParameterType="System.String" />
+            <TextFile Required="true" ParameterType="System.String" />
+            <Text Output="true" ParameterType="System.String" />
         </ParameterGroup>
         <Task>
-            <Using Namespace="System.Diagnostics"/>
             <Code Type="Fragment" Language="cs">
-                var psi = new ProcessStartInfo
-                {
-                    FileName = "dotnet",
-                    Arguments = $"run --project ../ChangelogAutomation/ChangelogAutomation.csproj -- {ChangelogFile} --content-type PlainText",
-                    RedirectStandardOutput = true
-                };
-                using var process = Process.Start(psi);
-                PlainText = process.StandardOutput.ReadToEnd();
-                process.WaitForExit();
-                if (process.ExitCode != 0)
-                {
-                    Log.LogError($"Process returned exit code {process.ExitCode}");
-                    return false;
-                }
+                Text = File.ReadAllText(TextFile);
             </Code>
         </Task>
     </UsingTask>


### PR DESCRIPTION
Adjusted dependent projects to reference pre-generated changelog text files instead of invoking extraction logic directly.